### PR TITLE
LM-2835 updated docker image to swisschains/dotnet:2.2-aspnetcore-run…

### DIFF
--- a/src/ApiRunner/Dockerfile
+++ b/src/ApiRunner/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime
+FROM swisschains/dotnet:2.2-aspnetcore-runtime
 ENTRYPOINT ["dotnet", "ApiRunner.dll"]
 ARG source=.
 WORKDIR /app

--- a/src/JobRunner/Dockerfile
+++ b/src/JobRunner/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime
+FROM swisschains/dotnet:2.2-aspnetcore-runtime
 ENTRYPOINT ["dotnet", "JobRunner.dll"]
 ARG source=.
 WORKDIR /app


### PR DESCRIPTION
…time to fix the outdated root certificate problem